### PR TITLE
docs: Cloud VM Python 3.11 setup note (uv)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This is a **Flask web app** for prompt-guided food image segmentation using Grou
 
 Python **3.11** is required. The system default may be 3.12+; use `python3.11` explicitly or activate the venv at `/workspace/.venv`.
 
+On Ubuntu 24.04, `python3.11` is not in apt. Install via [uv](https://docs.astral.sh/uv/): `curl -LsSf https://astral.sh/uv/install.sh | sh`, then `uv python install 3.11` and ensure `$HOME/.local/bin` is on `PATH`.
+
 ### Vendored model directories
 
 `webapp/GroundingDINO/` and `webapp/MobileSAM/` must contain the upstream source trees (cloned from GitHub). They are installed as editable packages (`pip install -e ... --no-build-isolation`). If these directories are empty, clone them:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a durable note to `AGENTS.md` for Cursor Cloud agents on Ubuntu 24.04, where `python3.11` is not available via apt. Documents installing Python 3.11 through `uv`.

No application code changes — environment setup only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf9bfa9d-a675-4621-96cd-34384f36525f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf9bfa9d-a675-4621-96cd-34384f36525f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance with Ubuntu-specific instructions for Python 3.11 installation, addressing availability concerns on Ubuntu 24.04 and providing alternative installation methods with PATH configuration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bempong-Sylvester-Obese/Food-segmentation-with-pre-trained-model/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->